### PR TITLE
Fix dark theme detection in firefox

### DIFF
--- a/newtab/newtab.html
+++ b/newtab/newtab.html
@@ -1,3 +1,2 @@
 <!DOCTYPE html><meta charset="utf-8"><script src="newtab.js"></script><title>New Tab</title>
 <meta name="color-scheme" content="light dark">
-<style media="prefers-color-scheme: dark">body{background:#000}</style>

--- a/newtab/newtab.js
+++ b/newtab/newtab.js
@@ -43,3 +43,9 @@ isRedirecting_ ? isNotChrome_ && localStorage.setOpener ? chrome_.tabs.query({cu
 : useLocation_ ? document.location.href = url_ : useTabs([]) : loadExtension_();
 
 !isNotChrome_ && focusContent_ && isRedirecting_ && close();
+
+// HTML media attribute doesn't work in Fiefox,
+// so colorscheme must be checked in js
+if(window.matchMedia("(prefers-color-scheme: dark)").matches) {
+  document.head.insertAdjacentHTML("beforeend", "<style>body{background:#000}</style>")
+}


### PR DESCRIPTION
HTML "media" attribute doesn't seem to work on webextension pages in Firefox (as of version 91.0.2)
But you can check the colorscheme in js